### PR TITLE
Ref. types for network classes, fix tests

### DIFF
--- a/include/server_lib/network/app_unit.h
+++ b/include/server_lib/network/app_unit.h
@@ -29,11 +29,13 @@ namespace network {
         {
         }
 
-        app_unit(const uint32_t value, const bool success = true);
+        using integer_type = uint32_t;
+
+        app_unit(const integer_type value, const bool success = true);
 
         template <typename T>
         app_unit(const T value, const bool success = true)
-            : app_unit(static_cast<uint32_t>(value), success)
+            : app_unit(static_cast<integer_type>(value), success)
         {
         }
 
@@ -81,7 +83,7 @@ namespace network {
 
         const std::string& as_string() const;
 
-        uint32_t as_integer() const;
+        integer_type as_integer() const;
 
         // print any type of data
         std::string to_printable_string() const;
@@ -93,7 +95,7 @@ namespace network {
 
         void set(const std::string& value, const bool success = true);
 
-        void set(const uint32_t value, const bool success = true);
+        void set(const integer_type value, const bool success = true);
 
         void set(const std::vector<app_unit>& nested, const bool success = true);
 
@@ -108,7 +110,7 @@ namespace network {
 
     private:
         using variant_type = boost::variant<std::string,
-                                            uint32_t,
+                                            integer_type,
                                             bool>;
 
         bool _success = false;

--- a/include/server_lib/network/app_unit_builder_i.h
+++ b/include/server_lib/network/app_unit_builder_i.h
@@ -20,17 +20,17 @@ namespace network {
 
         //Ability to create clones.
         //It is required if builder is used like protocol
-        virtual app_unit_builder_i* clone()
+        virtual app_unit_builder_i* clone() const
         {
             return nullptr;
         }
 
-        virtual app_unit create(const std::string&)
+        virtual app_unit create(const std::string&) const
         {
             return {};
         }
 
-        virtual app_unit create(const char* buff, const size_t sz)
+        virtual app_unit create(const char* buff, const size_t sz) const
         {
             return create(std::string { buff, sz });
         }

--- a/include/server_lib/network/dstream_builder.h
+++ b/include/server_lib/network/dstream_builder.h
@@ -18,12 +18,12 @@ namespace network {
 
         virtual ~dstream_builder() override = default;
 
-        app_unit_builder_i* clone() override
+        app_unit_builder_i* clone() const override
         {
             return new dstream_builder { _delimeter.c_str() };
         }
 
-        app_unit create(const std::string&) override;
+        app_unit create(const std::string&) const override;
 
         app_unit_builder_i& operator<<(std::string& network_data) override;
 

--- a/include/server_lib/network/integer_builder.h
+++ b/include/server_lib/network/integer_builder.h
@@ -15,7 +15,9 @@ namespace network {
 
         virtual ~integer_builder() override = default;
 
-        static std::string pack(const uint32_t);
+        using integer_type = app_unit::integer_type;
+
+        static std::string pack(const integer_type);
 
         app_unit_builder_i& operator<<(std::string& network_data) override;
 

--- a/include/server_lib/network/msg_builder.h
+++ b/include/server_lib/network/msg_builder.h
@@ -21,12 +21,14 @@ namespace network {
 
         virtual ~msg_builder() override = default;
 
-        app_unit_builder_i* clone() override
+        using size_type = integer_builder::integer_type;
+
+        app_unit_builder_i* clone() const override
         {
             return new msg_builder { _msg_max_size };
         }
 
-        app_unit create(const std::string& msg) override;
+        app_unit create(const std::string& msg) const override;
 
         app_unit_builder_i& operator<<(std::string& network_data) override;
 

--- a/include/server_lib/network/network_client.h
+++ b/include/server_lib/network/network_client.h
@@ -52,15 +52,15 @@ namespace network {
          */
         bool connect(
             const std::string& host,
-            std::size_t port,
-            const std::shared_ptr<app_unit_builder_i>& protocol,
+            uint16_t port,
+            const app_unit_builder_i* protocol,
             event_loop* callback_thread = nullptr,
             const disconnection_callback_type& disconnection_callback = nullptr,
             const receive_callback_type& receive_callback = nullptr,
-            std::uint32_t timeout_ms = 0,
-            std::uint8_t nb_threads = 0);
+            uint32_t timeout_ms = 0,
+            uint8_t nb_threads = 0);
 
-        void set_nb_workers(std::uint8_t nb_threads);
+        void set_nb_workers(uint8_t nb_threads);
 
         void disconnect(bool wait_for_removal = true);
 

--- a/include/server_lib/network/network_server.h
+++ b/include/server_lib/network/network_server.h
@@ -48,13 +48,13 @@ namespace network {
          *
          */
         bool start(const std::string& host,
-                   std::uint32_t port,
-                   const std::shared_ptr<app_unit_builder_i>& protocol,
+                   uint16_t port,
+                   const app_unit_builder_i* protocol,
                    event_loop* callback_thread = nullptr,
                    const on_new_connection_callback_type& callback = nullptr,
-                   std::uint8_t nb_threads = 0);
+                   uint8_t nb_threads = 0);
 
-        void set_nb_workers(std::uint8_t nb_threads);
+        void set_nb_workers(uint8_t nb_threads);
 
         void stop(bool wait_for_removal = false, bool recursive_wait_for_removal = true);
 

--- a/include/server_lib/network/persist_network_client.h
+++ b/include/server_lib/network/persist_network_client.h
@@ -71,16 +71,16 @@ namespace network {
          */
         bool connect(
             const std::string& host,
-            std::size_t port,
-            const std::shared_ptr<app_unit_builder_i>& protocol,
+            uint16_t port,
+            const app_unit_builder_i* protocol,
             event_loop* callback_thread = nullptr,
             const connect_callback_type& connect_callback = nullptr,
-            std::uint32_t timeout_ms = 0,
-            std::int32_t max_reconnects = 0,
-            std::uint32_t reconnect_interval_ms = 0,
-            std::uint8_t nb_threads = 0);
+            uint32_t timeout_ms = 0,
+            int32_t max_reconnects = 0,
+            uint32_t reconnect_interval_ms = 0,
+            uint8_t nb_threads = 0);
 
-        void set_nb_workers(std::uint8_t nb_threads);
+        void set_nb_workers(uint8_t nb_threads);
 
         void disconnect(bool wait_for_removal = true);
 
@@ -139,14 +139,14 @@ namespace network {
 
     private:
         std::string _host;
-        std::size_t _port = 0;
+        uint16_t _port = 0;
         event_loop* _callback_thread = nullptr;
         connect_callback_type _connect_callback;
-        std::uint32_t _connect_timeout_ms = 0;
-        std::int32_t _max_reconnects = 0;
-        std::int32_t _current_reconnect_attempts = 0;
-        std::uint32_t _reconnect_interval_ms = 0;
-        std::uint8_t _nb_threads = 1;
+        uint32_t _connect_timeout_ms = 0;
+        int32_t _max_reconnects = 0;
+        int32_t _current_reconnect_attempts = 0;
+        uint32_t _reconnect_interval_ms = 0;
+        uint8_t _nb_threads = 1;
         std::shared_ptr<app_unit_builder_i> _protocol;
 
         std::shared_ptr<tcp_client_i> _transport_layer;

--- a/include/server_lib/network/raw_builder.h
+++ b/include/server_lib/network/raw_builder.h
@@ -17,17 +17,17 @@ namespace network {
 
         virtual ~raw_builder() override = default;
 
-        app_unit_builder_i* clone() override
+        app_unit_builder_i* clone() const override
         {
             return new raw_builder;
         }
 
-        app_unit create(const std::string& buff) override
+        app_unit create(const std::string& buff) const override
         {
             return { buff };
         }
 
-        app_unit create(const char* buff, const size_t sz) override
+        app_unit create(const char* buff, const size_t sz) const override
         {
             return { buff, sz };
         }

--- a/include/server_lib/network/string_builder.h
+++ b/include/server_lib/network/string_builder.h
@@ -32,13 +32,13 @@ namespace network {
 
         void reset() override;
 
-        void set_size(const uint32_t size)
+        void set_size(const size_t size)
         {
             _size = size;
         }
 
     private:
-        uint32_t _size = 0;
+        size_t _size = 0;
 
         std::string _buffer;
 

--- a/include/server_lib/network/tcp_client_i.h
+++ b/include/server_lib/network/tcp_client_i.h
@@ -25,7 +25,7 @@ namespace network {
          * @param timeout_ms max time to connect in ms
          *
          */
-        virtual void connect(const std::string& addr, std::uint32_t port, std::uint32_t timeout_ms = 0) = 0;
+        virtual void connect(const std::string& addr, uint16_t port, uint32_t timeout_ms = 0) = 0;
 
         /**
          * stop the tcp client
@@ -54,7 +54,7 @@ namespace network {
         *
         * \param nb_threads number of threads
         */
-        virtual void set_nb_workers(std::uint8_t nb_threads) = 0;
+        virtual void set_nb_workers(uint8_t nb_threads) = 0;
 
     public:
         /**

--- a/include/server_lib/network/tcp_server_i.h
+++ b/include/server_lib/network/tcp_server_i.h
@@ -33,7 +33,7 @@ namespace network {
         * \param port port to be connected to
         * \param callback callback to be called on new connections (may be null, connections are then handled automatically by the tcp_server object)
         */
-        virtual void start(const std::string& host, std::uint32_t port, event_loop* callback_thread = nullptr, const on_new_connection_callback_type& callback = nullptr) = 0;
+        virtual void start(const std::string& host, uint16_t port, event_loop* callback_thread = nullptr, const on_new_connection_callback_type& callback = nullptr) = 0;
 
         /**
         * Disconnect the tcp_server if it was currently running.
@@ -63,7 +63,7 @@ namespace network {
         *
         * \param nb_threads number of threads
         */
-        virtual void set_nb_workers(std::uint8_t nb_threads) = 0;
+        virtual void set_nb_workers(uint8_t nb_threads) = 0;
     };
 
 } // namespace network

--- a/src/network/app_unit.cpp
+++ b/src/network/app_unit.cpp
@@ -22,7 +22,7 @@ namespace network {
     {
     }
 
-    app_unit::app_unit(const uint32_t value, const bool success)
+    app_unit::app_unit(const integer_type value, const bool success)
         : _success(success)
         , _data(value)
     {
@@ -85,7 +85,7 @@ namespace network {
         _data = value;
     }
 
-    void app_unit::set(const uint32_t value, const bool success)
+    void app_unit::set(const integer_type value, const bool success)
     {
         _success = success;
         _data = value;
@@ -117,9 +117,9 @@ namespace network {
             {
                 return std::is_same<std::string, T>::value;
             }
-            auto operator()(const uint32_t)
+            auto operator()(const app_unit::integer_type)
             {
-                return std::is_same<uint32_t, T>::value;
+                return std::is_same<app_unit::integer_type, T>::value;
             }
             auto operator()(const bool)
             {
@@ -136,7 +136,7 @@ namespace network {
             {
                 return data;
             }
-            auto operator()(const uint32_t data)
+            auto operator()(const app_unit::integer_type data)
             {
                 return std::to_string(data);
             }
@@ -155,7 +155,7 @@ namespace network {
             {
                 return data;
             }
-            auto operator()(const uint32_t data)
+            auto operator()(const app_unit::integer_type data)
             {
                 return integer_builder::pack(data);
             }
@@ -184,7 +184,7 @@ namespace network {
 
     bool app_unit::is_integer() const
     {
-        impl::is_lunit_type<uint32_t> check;
+        impl::is_lunit_type<integer_type> check;
         return boost::apply_visitor(check, _data);
     }
 
@@ -207,11 +207,11 @@ namespace network {
         return boost::get<std::string>(_data);
     }
 
-    uint32_t app_unit::as_integer() const
+    app_unit::integer_type app_unit::as_integer() const
     {
         SRV_ASSERT(is_integer(), "Logic unit is not a integer");
 
-        return boost::get<uint32_t>(_data);
+        return boost::get<integer_type>(_data);
     }
 
     std::string app_unit::to_printable_string() const

--- a/src/network/dstream_builder.cpp
+++ b/src/network/dstream_builder.cpp
@@ -4,7 +4,7 @@
 namespace server_lib {
 namespace network {
 
-    app_unit dstream_builder::create(const std::string& buff)
+    app_unit dstream_builder::create(const std::string& buff) const
     {
         std::string buff_ { buff };
         buff_.append(_delimeter);

--- a/src/network/msg_builder.cpp
+++ b/src/network/msg_builder.cpp
@@ -2,17 +2,21 @@
 #include <server_lib/asserts.h>
 
 #include <algorithm>
+#include <limits>
 
 namespace server_lib {
 namespace network {
 
-    app_unit msg_builder::create(const std::string& msg)
+    app_unit msg_builder::create(const std::string& msg) const
     {
         SRV_ASSERT(msg.size() <= _msg_max_size);
 
         app_unit msg_unit { true };
 
-        msg_unit << app_unit { integer_builder::pack(msg.size()) } << app_unit { msg };
+        auto sz = msg.size();
+        SRV_ASSERT(sz <= static_cast<size_type>(std::numeric_limits<size_type>::max()));
+
+        msg_unit << app_unit { integer_builder::pack(static_cast<size_type>(sz)) } << app_unit { msg };
         return msg_unit;
     }
 

--- a/src/network/network_client.cpp
+++ b/src/network/network_client.cpp
@@ -47,13 +47,13 @@ namespace network {
 
     bool network_client::connect(
         const std::string& host,
-        std::size_t port,
-        const std::shared_ptr<app_unit_builder_i>& protocol,
+        uint16_t port,
+        const app_unit_builder_i* protocol,
         event_loop* callback_thread,
         const disconnection_callback_type& disconnection_callback,
         const receive_callback_type& receive_callback,
-        std::uint32_t timeout_ms,
-        std::uint8_t nb_threads)
+        uint32_t timeout_ms,
+        uint8_t nb_threads)
     {
         try
         {
@@ -95,7 +95,7 @@ namespace network {
         return false;
     }
 
-    void network_client::set_nb_workers(std::uint8_t nb_threads)
+    void network_client::set_nb_workers(uint8_t nb_threads)
     {
         SRV_LOGC_TRACE("changed number of workers. New = " << nb_threads);
 

--- a/src/network/network_server.cpp
+++ b/src/network/network_server.cpp
@@ -37,11 +37,11 @@ namespace network {
     }
 
     bool network_server::start(const std::string& host,
-                               std::uint32_t port,
-                               const std::shared_ptr<app_unit_builder_i>& protocol,
+                               uint16_t port,
+                               const app_unit_builder_i* protocol,
                                event_loop* callback_thread,
                                const on_new_connection_callback_type& callback,
-                               std::uint8_t nb_threads)
+                               uint8_t nb_threads)
     {
         try
         {
@@ -74,7 +74,7 @@ namespace network {
         return false;
     }
 
-    void network_server::set_nb_workers(std::uint8_t nb_threads)
+    void network_server::set_nb_workers(uint8_t nb_threads)
     {
         SRV_LOGC_TRACE("changed number of workers. New = " << nb_threads);
 

--- a/src/network/persist_network_client.cpp
+++ b/src/network/persist_network_client.cpp
@@ -65,14 +65,14 @@ namespace network {
     }
 
     bool persist_network_client::connect(
-        const std::string& host, std::size_t port,
-        const std::shared_ptr<app_unit_builder_i>& protocol,
+        const std::string& host, uint16_t port,
+        const app_unit_builder_i* protocol,
         event_loop* callback_thread,
         const connect_callback_type& connect_callback,
-        std::uint32_t timeout_ms,
-        std::int32_t max_reconnects,
-        std::uint32_t reconnect_interval_ms,
-        std::uint8_t nb_threads)
+        uint32_t timeout_ms,
+        int32_t max_reconnects,
+        uint32_t reconnect_interval_ms,
+        uint8_t nb_threads)
     {
         try
         {
@@ -133,7 +133,7 @@ namespace network {
         return false;
     }
 
-    void persist_network_client::set_nb_workers(std::uint8_t nb_threads)
+    void persist_network_client::set_nb_workers(uint8_t nb_threads)
     {
         SRV_LOGC_TRACE("changed number of workers. Old = " << _nb_threads << ", New = " << nb_threads);
 
@@ -357,7 +357,7 @@ namespace network {
     {
         ++_current_reconnect_attempts;
 
-        connect(_host, _port, _protocol, _callback_thread, _connect_callback, _connect_timeout_ms, _max_reconnects,
+        connect(_host, _port, _protocol.get(), _callback_thread, _connect_callback, _connect_timeout_ms, _max_reconnects,
                 _reconnect_interval_ms, _nb_threads);
 
         if (!is_connected())

--- a/src/network/string_builder.cpp
+++ b/src/network/string_builder.cpp
@@ -11,21 +11,21 @@ namespace network {
         if (_ready)
             return *this;
 
-        if (_buffer.size() < static_cast<size_t>(_size))
+        if (_buffer.size() < _size)
         {
-            size_t left = static_cast<size_t>(_size) - _buffer.size();
+            size_t left = _size - _buffer.size();
             size_t add = std::min(network_data.size(), left);
 
             auto it = network_data.begin();
-            it += static_cast<long>(add);
+            it += static_cast<decltype(it)::difference_type>(add);
             _buffer.append(network_data.begin(), it);
 
             network_data.erase(0, add);
         }
 
-        SRV_ASSERT(_buffer.size() <= static_cast<size_t>(_size));
+        SRV_ASSERT(_buffer.size() <= _size);
 
-        if (_buffer.size() == static_cast<size_t>(_size))
+        if (_buffer.size() == _size)
         {
             _ready = true;
             if (!_buffer.empty())

--- a/src/network/tcp_client_impl.cpp
+++ b/src/network/tcp_client_impl.cpp
@@ -18,11 +18,11 @@
 namespace server_lib {
 namespace network {
 
-    void tcp_client_impl::connect(const std::string& addr, std::uint32_t port, std::uint32_t timeout_ms)
+    void tcp_client_impl::connect(const std::string& addr, uint16_t port, uint32_t timeout_ms)
     {
         SRV_LOGC_TRACE("attempts to connect");
 
-        _impl.connect(addr, port, timeout_ms);
+        _impl.connect(addr, static_cast<uint32_t>(port), timeout_ms);
         _impl.set_on_disconnection_handler(std::bind(&tcp_client_impl::on_diconnected, this));
 
         SRV_LOGC_TRACE("connected");
@@ -44,7 +44,7 @@ namespace network {
         return _impl.is_connected();
     }
 
-    void tcp_client_impl::set_nb_workers(std::uint8_t nb_threads)
+    void tcp_client_impl::set_nb_workers(uint8_t nb_threads)
     {
         _impl.get_io_service()->set_nb_workers(static_cast<size_t>(nb_threads));
     }

--- a/src/network/tcp_client_impl.h
+++ b/src/network/tcp_client_impl.h
@@ -14,13 +14,13 @@ namespace network {
     public:
         tcp_client_impl() = default;
 
-        void connect(const std::string& addr, std::uint32_t port, std::uint32_t timeout_ms = 0) override;
+        void connect(const std::string& addr, uint16_t port, uint32_t timeout_ms = 0) override;
 
         void disconnect(bool wait_for_removal = false) override;
 
         bool is_connected() const override;
 
-        void set_nb_workers(std::uint8_t nb_threads) override;
+        void set_nb_workers(uint8_t nb_threads) override;
 
         std::shared_ptr<tcp_connection_i> create_connection() override;
 

--- a/src/network/tcp_server_impl.cpp
+++ b/src/network/tcp_server_impl.cpp
@@ -18,7 +18,7 @@
 namespace server_lib {
 namespace network {
 
-    void tcp_server_impl::start(const std::string& host, std::uint32_t port, event_loop* callback_thread, const on_new_connection_callback_type& callback)
+    void tcp_server_impl::start(const std::string& host, uint16_t port, event_loop* callback_thread, const on_new_connection_callback_type& callback)
     {
         SRV_ASSERT(!is_running());
         SRV_ASSERT(callback);
@@ -30,7 +30,7 @@ namespace network {
             _callback_thread = callback_thread;
             _new_connection_handler = callback;
             auto new_connection_handler = std::bind(&tcp_server_impl::on_new_connection, this, std::placeholders::_1);
-            _impl.start(host, port, new_connection_handler);
+            _impl.start(host, static_cast<uint32_t>(port), new_connection_handler);
 
             SRV_LOGC_TRACE("started");
         }
@@ -76,7 +76,7 @@ namespace network {
         return _impl.is_running();
     }
 
-    void tcp_server_impl::set_nb_workers(std::uint8_t nb_threads)
+    void tcp_server_impl::set_nb_workers(uint8_t nb_threads)
     {
         _impl.get_io_service()->set_nb_workers(static_cast<size_t>(nb_threads));
     }

--- a/src/network/tcp_server_impl.h
+++ b/src/network/tcp_server_impl.h
@@ -17,13 +17,13 @@ namespace network {
     public:
         tcp_server_impl() = default;
 
-        void start(const std::string& host, std::uint32_t port, event_loop* callback_thread = nullptr, const on_new_connection_callback_type& callback = nullptr) override;
+        void start(const std::string& host, uint16_t port, event_loop* callback_thread = nullptr, const on_new_connection_callback_type& callback = nullptr) override;
 
         void stop(bool wait_for_removal = false, bool recursive_wait_for_removal = true) override;
 
         bool is_running(void) const override;
 
-        void set_nb_workers(std::uint8_t nb_threads) override;
+        void set_nb_workers(uint8_t nb_threads) override;
 
     private:
         bool on_new_connection(const std::shared_ptr<tacopie::tcp_client>&);

--- a/tests/network_app_unit_tests.cpp
+++ b/tests/network_app_unit_tests.cpp
@@ -12,7 +12,7 @@ namespace tests {
 
     using namespace server_lib::network;
 
-    BOOST_AUTO_TEST_SUITE(network_app_unit_tests)
+    BOOST_AUTO_TEST_SUITE(network_tests)
 
     BOOST_AUTO_TEST_CASE(raw_builder_recive_check)
     {

--- a/tests/network_basic_tests.cpp
+++ b/tests/network_basic_tests.cpp
@@ -16,7 +16,7 @@ namespace tests {
 
     using namespace server_lib::network;
 
-    BOOST_FIXTURE_TEST_SUITE(network_basic_tests, basic_network_fixture)
+    BOOST_FIXTURE_TEST_SUITE(network_tests, basic_network_fixture)
 
     BOOST_AUTO_TEST_CASE(tcp_connection_close_by_client_check)
     {
@@ -28,9 +28,7 @@ namespace tests {
         server_th.change_thread_name("!S");
         client_th.change_thread_name("!C");
 
-        auto protocol = std::make_shared<raw_builder>();
-
-        BOOST_REQUIRE(protocol);
+        raw_builder protocol;
 
         network_server server;
         network_client client;
@@ -82,7 +80,7 @@ namespace tests {
             connection->set_on_receive_handler(server_recieve_callback);
             connection->set_on_disconnect_handler(server_disconnect_callback);
 
-            BOOST_REQUIRE_NO_THROW(connection->send(protocol->create(ping_data)).commit());
+            BOOST_REQUIRE_NO_THROW(connection->send(protocol.create(ping_data)).commit());
 
             hold_connection = connection;
         };
@@ -92,7 +90,7 @@ namespace tests {
 
             BOOST_REQUIRE_EQUAL(unit.as_string(), ping_data);
 
-            BOOST_REQUIRE_NO_THROW(client.send(protocol->create(pong_data)).commit());
+            BOOST_REQUIRE_NO_THROW(client.send(protocol.create(pong_data)).commit());
         };
 
         auto client_disconnect_callback = []() {
@@ -100,11 +98,11 @@ namespace tests {
         };
 
         auto client_run = [&client, &host, &port, &protocol, &client_th, &client_recieve_callback, &client_disconnect_callback]() {
-            BOOST_REQUIRE(client.connect(host, port, protocol, &client_th, client_disconnect_callback, client_recieve_callback));
+            BOOST_REQUIRE(client.connect(host, port, &protocol, &client_th, client_disconnect_callback, client_recieve_callback));
         };
 
         server_th.start([&server, &host, &port, &protocol, &server_th, &server_new_connection_callback, &client_th, &client_run]() {
-            BOOST_REQUIRE(server.start(host, port, protocol, &server_th, server_new_connection_callback));
+            BOOST_REQUIRE(server.start(host, port, &protocol, &server_th, server_new_connection_callback));
 
             client_th.start([&]() { client_run(); });
         });
@@ -128,9 +126,7 @@ namespace tests {
         server_th.change_thread_name("!S");
         client_th.change_thread_name("!C");
 
-        auto protocol = std::make_shared<raw_builder>();
-
-        BOOST_REQUIRE(protocol);
+        raw_builder protocol;
 
         network_server server;
         network_client client;
@@ -175,7 +171,7 @@ namespace tests {
             connection->set_on_receive_handler(server_recieve_callback);
             connection->set_on_disconnect_handler(server_disconnect_callback);
 
-            BOOST_REQUIRE_NO_THROW(connection->send(protocol->create(ping_data)).commit());
+            BOOST_REQUIRE_NO_THROW(connection->send(protocol.create(ping_data)).commit());
 
             hold_connection = connection;
         };
@@ -185,7 +181,7 @@ namespace tests {
 
             BOOST_REQUIRE_EQUAL(unit.as_string(), ping_data);
 
-            BOOST_REQUIRE_NO_THROW(client.send(protocol->create(pong_data)).commit());
+            BOOST_REQUIRE_NO_THROW(client.send(protocol.create(pong_data)).commit());
         };
 
         auto client_disconnect_callback = [&client_th, &done_test, &done_test_cond_guard, &done_test_cond]() {
@@ -200,11 +196,11 @@ namespace tests {
         };
 
         auto client_run = [&client, &host, &port, &protocol, &client_th, &client_recieve_callback, &client_disconnect_callback]() {
-            BOOST_REQUIRE(client.connect(host, port, protocol, &client_th, client_disconnect_callback, client_recieve_callback));
+            BOOST_REQUIRE(client.connect(host, port, &protocol, &client_th, client_disconnect_callback, client_recieve_callback));
         };
 
         server_th.start([&server, &host, &port, &protocol, &server_th, &server_new_connection_callback, &client_th, &client_run]() {
-            BOOST_REQUIRE(server.start(host, port, protocol, &server_th, server_new_connection_callback));
+            BOOST_REQUIRE(server.start(host, port, &protocol, &server_th, server_new_connection_callback));
 
             client_th.start([&]() { client_run(); });
         });

--- a/tests/network_common.cpp
+++ b/tests/network_common.cpp
@@ -9,7 +9,7 @@
 namespace server_lib {
 namespace tests {
 
-    uint32_t basic_network_fixture::get_free_port()
+    uint16_t basic_network_fixture::get_free_port()
     {
         int result = 0;
 #if defined(SERVER_LIB_PLATFORM_LINUX)
@@ -38,8 +38,8 @@ namespace tests {
             close(socket_fd);
 #endif
         if (result < 1024)
-            return static_cast<int>(get_default_port());
-        return result;
+            return get_default_port();
+        return static_cast<uint16_t>(result);
     }
 
 } // namespace tests

--- a/tests/network_common.h
+++ b/tests/network_common.h
@@ -22,7 +22,7 @@ namespace tests {
             return 9999;
         }
 
-        uint32_t get_free_port();
+        uint16_t get_free_port();
     };
 
 } // namespace tests


### PR DESCRIPTION
**1.**
It could be more convenient to have ability to write:

```cpp
any_protocol_app_unit_builder protocol;

any_client.connect(host, port, &protocol);
server.start(host, port, &protocol)
```
instead of shared_ptr creation. In new case both variant become available.

**2.** 
std::uint32_t and etc. -> uint32_t. It should be without std namespace. 

**3.**
Unit test network_tests/persist_connection_send_check has some mistakes
